### PR TITLE
feat(court): stage progression with STAGE_REQS table

### DIFF
--- a/court/emperor.py
+++ b/court/emperor.py
@@ -23,7 +23,7 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from . import registry, state as state_mod, ticker, dispatcher
+from . import registry, state as state_mod, ticker, dispatcher, stages
 
 ROOT = Path(__file__).resolve().parent.parent
 PROVINCES_DIR = ROOT / "provinces"
@@ -67,6 +67,7 @@ def run_one_tick(
         reports.append(report)
 
     _check_milestones(state)
+    stages.maybe_advance(state, manifests)
     return reports
 
 
@@ -82,6 +83,12 @@ def _check_milestones(state: Dict[str, Any]) -> None:
             triggered = True
         elif mid == "first-city" and treasury.get("jian-zhu", 0) >= 1:
             triggered = True
+        elif mid == "shang-yang-reform" and treasury.get("wen-shu", 0) >= 300 and treasury.get("hu-ji", 0) >= 60:
+            triggered = True
+        elif mid.startswith("fall-of-"):
+            triggered = _check_conquest_milestone(mid, state)
+        elif mid == "yi-tong" and state.get("stage") in {"yi-tong", "di-guo", "wan-shi"}:
+            triggered = True
         if triggered:
             m["achieved"] = True
             m["achieved_at"] = state["tick"]
@@ -92,6 +99,23 @@ def _check_milestones(state: Dict[str, Any]) -> None:
                 "text": f"里程碑达成：{m.get('name', mid)}",
                 "severity": "epic",
             })
+
+
+def _check_conquest_milestone(mid: str, state: Dict[str, Any]) -> bool:
+    order = [
+        ("fall-of-han", 120),
+        ("fall-of-zhao", 240),
+        ("fall-of-wei", 360),
+        ("fall-of-chu", 520),
+        ("fall-of-yan", 680),
+        ("fall-of-qi", 860),
+    ]
+    required = dict(order).get(mid)
+    if required is None:
+        return False
+    treasury = state.get("treasury", {})
+    force = treasury.get("bing-qi", 0) + treasury.get("bing-ma", 0) + treasury.get("cheng-chi", 0) * 20
+    return force >= required
 
 
 def main() -> int:

--- a/court/stages.py
+++ b/court/stages.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List
+
+
+STAGE_ORDER = [
+    "qin-yi",
+    "chun-qiu",
+    "zhan-guo",
+    "heng-sao",
+    "yi-tong",
+    "di-guo",
+    "wan-shi",
+]
+
+STAGE_NAMES = {
+    "qin-yi": "秦邑",
+    "chun-qiu": "春秋",
+    "zhan-guo": "战国",
+    "heng-sao": "横扫",
+    "yi-tong": "一统",
+    "di-guo": "帝国",
+    "wan-shi": "万世",
+}
+
+
+STAGE_REQS: Dict[str, Dict[str, Any]] = {
+    "qin-yi": {
+        "next": "chun-qiu",
+        "min_year": 40,
+        "treasury": {"wen-shu": 500, "gong-ju": 200, "hu-ji": 100, "jian-zhu": 5},
+        "milestones": ["first-100-wenshu", "first-city"],
+        "text": "秦邑渐强，诸郡来归，入春秋之局。",
+    },
+    "chun-qiu": {
+        "next": "zhan-guo",
+        "min_year": 300,
+        "treasury": {"qian-liang": 2000, "bing-qi": 500, "cheng-chi": 10},
+        "milestones": ["shang-yang-reform"],
+        "text": "礼崩而法兴，群雄并起，秦入战国。",
+    },
+    "zhan-guo": {
+        "next": "heng-sao",
+        "min_year": 450,
+        "treasury": {"bing-qi": 2000, "bing-ma": 1200, "cheng-chi": 30},
+        "milestones": ["shang-yang-reform"],
+        "text": "变法强秦，兵甲既具，东出横扫。",
+    },
+    "heng-sao": {
+        "next": "yi-tong",
+        "min_year": 500,
+        "treasury": {"bing-qi": 3000, "bing-ma": 2000, "qian-liang": 5000},
+        "milestones": [
+            "fall-of-han",
+            "fall-of-zhao",
+            "fall-of-wei",
+            "fall-of-chu",
+            "fall-of-yan",
+            "fall-of-qi",
+        ],
+        "ceremonial_tick": True,
+        "text": "六合既并，天下归秦。",
+    },
+    "yi-tong": {
+        "next": "di-guo",
+        "min_year": 501,
+        "treasury": {"zhao-shu": 30, "dian-ji": 30, "yi-li": 20},
+        "milestones": ["yi-tong"],
+        "text": "书同文，车同轨，度同制，帝国成形。",
+    },
+    "di-guo": {
+        "next": "wan-shi",
+        "min_year": 800,
+        "treasury": {"cheng-chi": 80, "dian-ji": 120, "yi-li": 100},
+        "milestones": [],
+        "civilization_total": 500,
+        "text": "功业入典，秦制长行，开万世之基。",
+    },
+    "wan-shi": {
+        "next": None,
+        "min_year": 800,
+        "treasury": {},
+        "milestones": [],
+        "civilization_total": 1000,
+        "text": "万世之后仍是秦，文明周而复始。",
+    },
+}
+
+
+def maybe_advance(state: Dict[str, Any], manifests: Iterable[Dict[str, Any]] = ()) -> Dict[str, Any]:
+    stage = state.get("stage", "qin-yi")
+    req = STAGE_REQS.get(stage, STAGE_REQS["qin-yi"])
+    progress = _progress(state, req)
+    state["stage_progress"] = round(progress, 4)
+
+    advanced = False
+    if req.get("next") and progress >= 1.0:
+        _advance(state, req, manifests)
+        advanced = True
+        state["stage_progress"] = round(_progress(state, STAGE_REQS[state["stage"]]), 4)
+
+    return {
+        "stage": state["stage"],
+        "stage_progress": state["stage_progress"],
+        "advanced": advanced,
+    }
+
+
+def evaluate(state: Dict[str, Any], manifests: Iterable[Dict[str, Any]]) -> Dict[str, Any]:
+    return maybe_advance(state, manifests)
+
+
+def describe(stage: str) -> Dict[str, Any]:
+    req = STAGE_REQS.get(stage, STAGE_REQS["qin-yi"])
+    return {
+        "stage": stage,
+        "name": STAGE_NAMES.get(stage, stage),
+        "next_stage": req.get("next"),
+        "requirements": _describe_requirements(req),
+    }
+
+
+def ceremonial_manifests(manifests: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    return [m for m in manifests if m.get("role") == "ceremonial"]
+
+
+def _advance(state: Dict[str, Any], req: Dict[str, Any], manifests: Iterable[Dict[str, Any]]) -> None:
+    next_stage = req.get("next")
+    if not next_stage:
+        return
+    if req.get("ceremonial_tick"):
+        _apply_unification_cost(state)
+    state["stage"] = next_stage
+    state["seal"] = f"seal-{next_stage}-{state.get('tick', 0)}"
+    state.setdefault("events", []).insert(0, {
+        "tick": state.get("tick", 0),
+        "year": state.get("year", 0),
+        "type": "epoch",
+        "from_province": None,
+        "text": req.get("text", f"帝国进入 {STAGE_NAMES.get(next_stage, next_stage)}。"),
+        "severity": "epic",
+    })
+    if req.get("ceremonial_tick"):
+        for manifest in ceremonial_manifests(manifests):
+            state.setdefault("events", []).insert(0, {
+                "tick": state.get("tick", 0),
+                "year": state.get("year", 0),
+                "type": "ceremony",
+                "from_province": manifest.get("id"),
+                "text": f"{manifest.get('province', manifest.get('id'))}奉诏参一统大典。",
+                "severity": "epic",
+            })
+    if len(state["events"]) > 200:
+        state["events"] = state["events"][:200]
+
+
+def _progress(state: Dict[str, Any], req: Dict[str, Any]) -> float:
+    ratios: List[float] = []
+    min_year = int(req.get("min_year", 0))
+    if min_year:
+        ratios.append(min(1.0, state.get("year", 0) / min_year))
+
+    for key, target in req.get("treasury", {}).items():
+        ratios.append(min(1.0, state.get("treasury", {}).get(key, 0) / target))
+
+    for milestone_id in req.get("milestones", []):
+        ratios.append(1.0 if _milestone_achieved(state, milestone_id) else 0.0)
+
+    civilization_target = int(req.get("civilization_total", 0))
+    if civilization_target:
+        current = sum(int(v) for v in state.get("civilization_index", {}).values())
+        ratios.append(min(1.0, current / civilization_target))
+
+    return 1.0 if not ratios else sum(ratios) / len(ratios)
+
+
+def _describe_requirements(req: Dict[str, Any]) -> List[Dict[str, Any]]:
+    out: List[Dict[str, Any]] = []
+    if req.get("min_year"):
+        out.append({"key": "year", "label": "帝国年", "target": req["min_year"]})
+    for key, target in req.get("treasury", {}).items():
+        out.append({"key": f"treasury.{key}", "label": key, "target": target})
+    for milestone_id in req.get("milestones", []):
+        out.append({"key": f"milestone.{milestone_id}", "label": milestone_id, "target": 1})
+    if req.get("civilization_total"):
+        out.append({"key": "civilization_total", "label": "文明指数", "target": req["civilization_total"]})
+    return out
+
+
+def _apply_unification_cost(state: Dict[str, Any]) -> None:
+    treasury = state.setdefault("treasury", {})
+    for key, value in list(treasury.items()):
+        treasury[key] = max(0, int(value) // 2)
+    buffs = state.setdefault("buffs", {})
+    buffs["yi-tong-production"] = {"multiplier": 2, "since_tick": state.get("tick", 0)}
+
+
+def _milestone_achieved(state: Dict[str, Any], milestone_id: str) -> bool:
+    return any(
+        m.get("id") == milestone_id and m.get("achieved")
+        for m in state.get("milestones", [])
+    )

--- a/docs/protocol/state.schema.json
+++ b/docs/protocol/state.schema.json
@@ -92,6 +92,14 @@
     "seal": {
       "type": ["string", "null"],
       "description": "最近一次玉玺 ID；阶段晋升或一统时刷新。"
+    },
+    "buffs": {
+      "type": "object",
+      "description": "阶段仪式赋予的长期加成。键为 buff ID，值为任意结构。",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": true
+      }
     }
   },
   "$defs": {

--- a/tests/test_stages.py
+++ b/tests/test_stages.py
@@ -1,0 +1,82 @@
+import copy
+import unittest
+
+from court import stages
+
+
+BASE_STATE = {
+    "schema_version": 1,
+    "dynasty": "秦",
+    "tick": 0,
+    "year": 0,
+    "stage": "qin-yi",
+    "stage_progress": 0,
+    "treasury": {},
+    "provinces": {},
+    "events": [],
+    "milestones": [
+        {"id": "first-100-wenshu", "achieved": False},
+        {"id": "first-city", "achieved": False},
+        {"id": "fall-of-han", "achieved": False},
+        {"id": "fall-of-zhao", "achieved": False},
+        {"id": "fall-of-wei", "achieved": False},
+        {"id": "fall-of-chu", "achieved": False},
+        {"id": "fall-of-yan", "achieved": False},
+        {"id": "fall-of-qi", "achieved": False},
+    ],
+    "stats": {},
+    "seal": None,
+}
+
+
+class StageTests(unittest.TestCase):
+    def test_qin_yi_does_not_advance_when_requirements_are_missing(self):
+        state = copy.deepcopy(BASE_STATE)
+        result = stages.maybe_advance(state)
+        self.assertFalse(result["advanced"])
+        self.assertEqual(state["stage"], "qin-yi")
+        self.assertLess(state["stage_progress"], 1)
+
+    def test_qin_yi_advances_to_chun_qiu_when_requirements_are_met(self):
+        state = copy.deepcopy(BASE_STATE)
+        state["year"] = 40
+        state["tick"] = 960
+        state["treasury"] = {
+            "wen-shu": 500,
+            "gong-ju": 200,
+            "hu-ji": 100,
+            "jian-zhu": 5,
+        }
+        for milestone in state["milestones"]:
+            if milestone["id"] in {"first-100-wenshu", "first-city"}:
+                milestone["achieved"] = True
+
+        result = stages.maybe_advance(state)
+
+        self.assertTrue(result["advanced"])
+        self.assertEqual(state["stage"], "chun-qiu")
+        self.assertEqual(state["seal"], "seal-chun-qiu-960")
+        self.assertEqual(state["events"][0]["type"], "epoch")
+
+    def test_heng_sao_to_yi_tong_halves_treasury_and_adds_buff(self):
+        state = copy.deepcopy(BASE_STATE)
+        state["stage"] = "heng-sao"
+        state["year"] = 500
+        state["tick"] = 12000
+        state["treasury"] = {"bing-qi": 3000, "bing-ma": 2000, "qian-liang": 5000}
+        for milestone in state["milestones"]:
+            milestone["achieved"] = milestone["id"].startswith("fall-of-")
+
+        result = stages.maybe_advance(state, [{"id": "brainfuck", "province": "奇技郡", "role": "ceremonial"}])
+
+        self.assertTrue(result["advanced"])
+        self.assertEqual(state["stage"], "yi-tong")
+        self.assertEqual(state["treasury"]["bing-qi"], 1500)
+        self.assertEqual(state["treasury"]["bing-ma"], 1000)
+        self.assertEqual(state["treasury"]["qian-liang"], 2500)
+        self.assertIn("yi-tong-production", state["buffs"])
+        self.assertEqual(state["events"][0]["type"], "ceremony")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #12

## Summary
- new court/stages.py with STAGE_REQS table for all 7 stages and maybe_advance(state, manifests)
- emperor.py invokes stages.maybe_advance after milestone check each tick
- state.schema.json adds buffs field for unification ceremony permanent buff
- tests/test_stages.py covers no-advance, qin-yi -> chun-qiu, and heng-sao -> yi-tong (treasury halved + buff + ceremonial events)
- heng-sao -> yi-tong handled as a ceremonial tick: halves treasury, sets yi-tong-production buff, inserts ceremony events for all ceremonial provinces

## Validation
- python -m unittest tests.test_stages -v (3 tests pass)
- python tools/validate_all.py