### PR TITLE
feat(v0.4): RFC 0001 + chain mode MVP (closes #51 #52)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,5 @@ provinces/go/main_bin.exe
 *.log
 empire/state.backup*.json
 empire/seals/*.svg
+empire/chains/*.json
 provinces/glsl/artifacts/

--- a/court/chain.py
+++ b/court/chain.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import copy
+import json
+import re
+import time
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Optional
+
+from . import dispatcher, ticker
+
+
+CHAIN_DIR_NAME = "chains"
+DEFAULT_MAX_STEPS = 8
+DEFAULT_MAX_ELAPSED_S = 30.0
+_SAFE_RE = re.compile(r"[^a-z0-9-]+")
+
+
+RunProvince = Callable[[Dict[str, Any], Dict[str, Any]], Dict[str, Any]]
+
+
+def run_chain(
+    *,
+    state: Dict[str, Any],
+    manifests: Iterable[Dict[str, Any]],
+    province_ids: List[str],
+    title: str,
+    payload: Optional[Dict[str, Any]] = None,
+    empire_dir: Optional[Path] = None,
+    max_steps: int = DEFAULT_MAX_STEPS,
+    max_elapsed_s: float = DEFAULT_MAX_ELAPSED_S,
+    run_province: RunProvince = dispatcher.run_province,
+) -> Dict[str, Any]:
+    tick = int(state.get("tick", 0))
+    selected_ids = list(province_ids[:max(0, max_steps)])
+    chain_id = build_chain_id(tick, selected_ids)
+    by_id = {m.get("id"): m for m in manifests}
+    start = time.monotonic()
+    steps: List[Dict[str, Any]] = []
+    event_texts: List[Dict[str, Any]] = []
+    payload_obj = dict(payload or {})
+
+    for index, province_id in enumerate(selected_ids):
+        if time.monotonic() - start > max_elapsed_s:
+            steps.append(_synthetic_step(index, province_id, "timeout", "chain elapsed-time limit exceeded"))
+            continue
+        manifest = by_id.get(province_id)
+        if manifest is None:
+            steps.append(_synthetic_step(index, province_id, "missing", "province manifest not found"))
+            continue
+        if (state.get("provinces") or {}).get(province_id, {}).get("quarantined"):
+            steps.append(_synthetic_step(index, province_id, "quarantined", "province is quarantined"))
+            continue
+
+        dispatch = ticker.build_dispatch(state, manifest)
+        dispatch["dispatch_id"] = f"{chain_id}-{index:02d}-{_safe(province_id)}"
+        dispatch["dispatch_type"] = "ceremony"
+        dispatch.setdefault("expects", {})["max_event_count"] = 2
+        dispatch.setdefault("context", {})["chain"] = {
+            "chain_id": chain_id,
+            "title": title,
+            "step_index": index,
+            "step_count": len(selected_ids),
+            "payload": payload_obj,
+            "previous": copy.deepcopy(steps),
+        }
+
+        result = run_province(manifest, dispatch)
+        step = _result_step(index, province_id, result)
+        steps.append(step)
+        if result.get("ok"):
+            for event in result.get("events") or []:
+                event_texts.append({
+                    "province_id": province_id,
+                    "type": event.get("type", "system"),
+                    "severity": event.get("severity", "info"),
+                    "text": event.get("text", ""),
+                })
+
+    status = _final_status(steps)
+    elapsed_ms = int((time.monotonic() - start) * 1000)
+    record: Dict[str, Any] = {
+        "chain_id": chain_id,
+        "tick": tick,
+        "year": int(state.get("year", 0)),
+        "title": title,
+        "province_ids": selected_ids,
+        "status": status,
+        "payload": payload_obj,
+        "steps": steps,
+        "events": event_texts,
+        "elapsed_ms": elapsed_ms,
+        "artifact": None,
+    }
+
+    artifact = _write_artifact(record, empire_dir) if empire_dir is not None else None
+    record["artifact"] = artifact
+    _push_chain_event(state, title, len(selected_ids), status, artifact)
+    return record
+
+
+def build_chain_id(tick: int, province_ids: List[str]) -> str:
+    suffix = "-".join(_safe(pid) for pid in province_ids) or "empty"
+    return f"chain-{tick:06d}-{suffix}"
+
+
+def _safe(value: str) -> str:
+    return _SAFE_RE.sub("-", str(value).lower()).strip("-") or "unknown"
+
+
+def _synthetic_step(index: int, province_id: str, status: str, message: str) -> Dict[str, Any]:
+    return {
+        "index": index,
+        "province_id": province_id,
+        "status": status,
+        "ok": False,
+        "event_count": 0,
+        "error": {"code": f"CHAIN_{status.upper()}", "message": message},
+    }
+
+
+def _result_step(index: int, province_id: str, result: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "index": index,
+        "province_id": province_id,
+        "status": result.get("__status", "passed" if result.get("ok") else "failed"),
+        "ok": bool(result.get("ok")),
+        "event_count": len(result.get("events") or []),
+        "error": result.get("error"),
+    }
+
+
+def _final_status(steps: List[Dict[str, Any]]) -> str:
+    if not steps:
+        return "failed"
+    passed = sum(1 for step in steps if step.get("ok"))
+    if passed == len(steps):
+        return "passed"
+    if passed == 0:
+        return "failed"
+    return "partial"
+
+
+def _write_artifact(record: Dict[str, Any], empire_dir: Path) -> Optional[str]:
+    chain_dir = empire_dir / CHAIN_DIR_NAME
+    try:
+        chain_dir.mkdir(parents=True, exist_ok=True)
+        out_path = chain_dir / f"{record['chain_id']}.json"
+        out_path.write_text(json.dumps(record, ensure_ascii=False, indent=2), encoding="utf-8")
+        return f"{CHAIN_DIR_NAME}/{out_path.name}"
+    except OSError:
+        return None
+
+
+def _push_chain_event(state: Dict[str, Any], title: str, step_count: int,
+                      status: str, artifact: Optional[str]) -> None:
+    severity = "epic" if artifact else "warn"
+    state.setdefault("events", []).insert(0, {
+        "tick": state.get("tick", 0),
+        "year": state.get("year", 0),
+        "type": "chain",
+        "from_province": None,
+        "text": f"{title}：{step_count} 郡接力，status={status}",
+        "severity": severity,
+        "artifact": artifact,
+    })

--- a/court/emperor.py
+++ b/court/emperor.py
@@ -23,7 +23,7 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from . import registry, state as state_mod, ticker, dispatcher, stages, recruitment
+from . import registry, state as state_mod, ticker, dispatcher, stages, recruitment, chain
 
 ROOT = Path(__file__).resolve().parent.parent
 PROVINCES_DIR = ROOT / "provinces"
@@ -127,6 +127,9 @@ def main() -> int:
     ap = argparse.ArgumentParser(prog="emperor")
     ap.add_argument("--ticks", type=int, default=1, help="连续运行多少 tick（默认 1，可设为 0 仅做 build）")
     ap.add_argument("--province", default=None, help="只调度指定郡，调试用")
+    ap.add_argument("--chain", default=None, help="按逗号分隔的郡 id 运行 chain mode，例如 python,c,sql")
+    ap.add_argument("--chain-title", default="书同文小典", help="chain mode 标题")
+    ap.add_argument("--chain-payload", default="{}", help="chain mode payload JSON object")
     ap.add_argument("--no-build", action="store_true", help="跳过 build 步骤")
     ap.add_argument("--state-path", default=str(STATE_PATH))
     ap.add_argument("--quiet", action="store_true")
@@ -145,6 +148,42 @@ def main() -> int:
         if failed and not args.quiet:
             print(f"[emperor] build 失败：{failed}", file=sys.stderr)
         manifests = [m for m in manifests if m["id"] not in failed]
+
+    if args.chain:
+        try:
+            payload = json.loads(args.chain_payload)
+        except json.JSONDecodeError as exc:
+            print(f"[emperor] --chain-payload 不是合法 JSON：{exc}", file=sys.stderr)
+            return 2
+        if not isinstance(payload, dict):
+            print("[emperor] --chain-payload 必须是 JSON object", file=sys.stderr)
+            return 2
+        province_ids = [p.strip() for p in args.chain.split(",") if p.strip()]
+        record = chain.run_chain(
+            state=state,
+            manifests=manifests,
+            province_ids=province_ids,
+            title=args.chain_title,
+            payload=payload,
+            empire_dir=empire_dir,
+        )
+        state_mod.save_state(state, state_path)
+        state_mod.append_history(empire_dir / "history.jsonl", [{
+            "tick": state.get("tick", 0),
+            "year": state.get("year", 0),
+            "type": "chain",
+            "chain_id": record["chain_id"],
+            "status": record["status"],
+            "artifact": record.get("artifact"),
+            "steps": record.get("steps", []),
+        }])
+        if not args.quiet:
+            print(
+                f"[chain {record['chain_id']}] {record['status']} "
+                f"artifact={record.get('artifact')}",
+                file=sys.stderr,
+            )
+        return 0
 
     if args.ticks <= 0:
         return 0
@@ -166,7 +205,7 @@ def main() -> int:
             )
 
     state_mod.save_state(state, state_path)
-    state_mod.append_history(HISTORY_PATH, all_reports)
+    state_mod.append_history(empire_dir / "history.jsonl", all_reports)
 
     if not args.quiet:
         print(f"[emperor] state 写回 {state_path}", file=sys.stderr)

--- a/docs/rfcs/0001-chain-mode.md
+++ b/docs/rfcs/0001-chain-mode.md
@@ -1,99 +1,253 @@
 # RFC 0001: Chain Mode
 
 - Author: @maintainers
-- Status: Draft
+- Status: Accepted
 - Created: 2026-05-04
+- Accepted: 2026-05-04
 - Target Milestone: V0.4
-- Related Issues: TBD
+- Related Issues: #51, #52
 
 ## Summary
 
-Chain mode lets the court send one shared dispatch through multiple provinces in a deterministic order. Each province appends a stamp-like contribution, and the court records the ordered chain as one epic event or artifact.
+Chain mode is a **court-owned orchestration mode** that sends a shared ceremonial payload through an ordered list of provinces and writes one deterministic artifact at the end.
 
-This RFC is a placeholder draft to reserve the first V0.4 protocol-design slot. It does not implement chain mode yet.
+The first implementation is intentionally conservative:
+
+- It does **not** change `protocol_version = 2`;
+- It does **not** require any province to implement a new stdin/stdout shape;
+- It does **not** merge per-step `deltas` into `empire/state.json`;
+- It records chain output as an artifact plus one court event.
+
+In other words, chain mode is a replayable “multi-province ceremony” built on top of the existing v2 dispatch contract.
 
 ## Motivation
 
-V0.3 froze the v2 single-province dispatch contract. V0.4 needs a way to express collaborative multi-province work without breaking existing province stdout/output semantics.
+V0.3 froze the v2 single-province dispatch contract. V0.4 needs a visible collaboration primitive without reopening the protocol.
 
-Chain mode should support:
+Chain mode supports:
 
-- ceremonial relay events;
-- multi-language transformation demos;
-- future “书同文” public artifacts;
-- deterministic replay in CI.
+- multi-language relay demos;
+- ceremonial “书同文” artifacts;
+- deterministic CI replay;
+- future dashboard timeline/gallery views;
+- a safe stepping stone toward richer graph modes in V0.5+.
 
 ## Scope
 
 ### In scope
 
-- A court-owned orchestration mode that calls existing provinces one by one;
-- v2-compatible output from each province;
-- explicit failure policy for partial chains;
-- history/event representation.
+- A deterministic court module (`court/chain.py`);
+- Ordered province selection by explicit ids;
+- Per-step dispatch through existing `dispatcher.run_province(manifest, dispatch)`;
+- Artifact writing under `empire/chains/`;
+- One court event with `type=chain` and `artifact=<relative path>`;
+- Unit tests for order, failure policy, and artifact generation.
 
 ### Out of scope
 
-- Requiring provinces to implement a new protocol version;
-- Networked provinces;
+- New `protocol_version`;
+- New required schema fields;
 - Parallel graph execution;
-- Browser-only execution.
+- Browser-only execution;
+- Networked or remote provinces;
+- Merging chain step resource deltas into treasury.
 
 ## Design
 
-Draft direction:
+### 1. Public API
 
-1. `court.chain` builds a list of province ids and an initial payload.
-2. Each step calls existing `dispatcher.run_province(manifest, dispatch)`.
-3. The court stores intermediate outputs in memory only.
-4. The final chain record is emitted as a court event.
+The MVP exposes a pure Python API:
 
-Open design choice: whether chain payload is carried inside `dispatch.context.chain` or as a separate court-only wrapper that never reaches province schemas.
+```python
+from court import chain
+
+record = chain.run_chain(
+    state=state,
+    manifests=manifests,
+    province_ids=["python", "c", "sql"],
+    title="书同文小典",
+    payload={"text": "秦法同文"},
+    empire_dir=Path("empire"),
+)
+```
+
+`run_chain` returns a record object:
+
+```json
+{
+  "chain_id": "chain-000123-python-c-sql",
+  "tick": 123,
+  "title": "书同文小典",
+  "province_ids": ["python", "c", "sql"],
+  "status": "passed",
+  "steps": [
+    {
+      "index": 0,
+      "province_id": "python",
+      "status": "passed",
+      "ok": true,
+      "event_count": 1,
+      "error": null
+    }
+  ],
+  "artifact": "chains/chain-000123-python-c-sql.json"
+}
+```
+
+### 2. Dispatch shape
+
+Each province still receives valid v2 input:
+
+```json
+{
+  "protocol_version": 2,
+  "dispatch": {
+    "schema_version": 1,
+    "dispatch_id": "chain-000123-00-python",
+    "tick": 123,
+    "dispatch_type": "ceremony",
+    "context": {
+      "chain": {
+        "chain_id": "chain-000123-python-c-sql",
+        "title": "书同文小典",
+        "step_index": 0,
+        "step_count": 3,
+        "previous": []
+      }
+    }
+  }
+}
+```
+
+`dispatch.context.chain` is an **optional additive context object**. Existing provinces may ignore it. Because `context` already exists and unknown keys are tolerated, this remains v2-compatible.
+
+### 3. Step semantics
+
+For every province id:
+
+1. Find manifest by id;
+2. Skip missing/quarantined province as a failed step;
+3. Build a normal dispatch with `ticker.build_dispatch`;
+4. Override:
+   - `dispatch_id` to `chain-<tick>-<index>-<province>`;
+   - `dispatch_type` to `ceremony`;
+   - `context.chain` to current chain metadata;
+   - `expects.max_event_count` to `2`;
+5. Run `dispatcher.run_province`;
+6. Store a summarized step result;
+7. Append successful province events into the chain artifact only.
+
+### 4. Failure policy
+
+The MVP uses **fail-soft** policy:
+
+- Continue after failed steps;
+- Mark final `status` as `partial` if at least one step passed and one failed;
+- Mark final `status` as `failed` if all steps failed;
+- Mark final `status` as `passed` if all steps passed.
+
+The court does **not** call `state.merge_delta` for chain steps. Therefore chain mode does not affect treasury, province loyalty, fail streak, cooldown, or quarantine. This avoids surprising side effects and keeps chain deterministic.
+
+### 5. Artifact path
+
+Artifacts are written under:
+
+```text
+empire/chains/<chain_id>.json
+```
+
+The JSON artifact contains:
+
+- chain metadata;
+- original payload;
+- step summaries;
+- province event texts;
+- elapsed time;
+- final status.
+
+`empire/chains/*.json` is a runtime artifact and should be ignored by git.
+
+### 6. Court event
+
+After the chain completes, `run_chain` inserts one event at the head of `state.events`:
+
+```json
+{
+  "type": "chain",
+  "from_province": null,
+  "text": "书同文小典：3 郡接力，status=passed",
+  "severity": "epic",
+  "artifact": "chains/chain-000123-python-c-sql.json"
+}
+```
+
+If artifact writing fails, the chain still returns a record with `artifact=null` and emits a warning-severity event.
 
 ## Compatibility
 
-- Protocol version impact: v2-compatible if province stdin/stdout stay unchanged.
-- Schema impact: ideally additive optional fields only.
-- Existing province impact: none for non-chain ticks.
+- Protocol version impact: **none** (`protocol_version` remains `2`);
+- Schema impact: additive optional `dispatch.context.chain`;
+- Existing province impact: none;
+- Existing tick behavior: unchanged unless chain mode is explicitly called.
+
+This is compatible with the V0.3 freeze declaration because it adds optional context and court-only artifacts; it does not remove, rename, or retype any frozen field.
 
 ## Security Considerations
 
 Chain mode multiplies subprocess invocations, so it must respect:
 
-- per-province timeout;
-- stderr/stdout limits;
-- `manifest.permissions` environment behavior;
-- total chain step limit;
-- total chain elapsed-time limit.
+- each province’s existing `timeout_ms`;
+- stderr truncation and stdout strict JSON checks;
+- `manifest.permissions` env behavior;
+- maximum step count, default 8;
+- maximum total elapsed time, default 30 seconds;
+- no network beyond per-manifest permissions.
+
+The MVP should not introduce new runner types or shell interpolation.
 
 ## Migration Plan
 
-No migration for existing provinces. Chain mode starts as an opt-in court command or scheduled ceremonial event.
+No migration is required.
+
+Existing provinces do not need to change. Provinces that want richer chain-specific behavior may optionally inspect `dispatch.context.chain` later.
 
 ## Testing Plan
 
-- Unit-test deterministic province order;
-- Unit-test failure policies;
-- Integration-test a small chain using Python/C/SQL or mock manifests;
-- Verify `python tools/validate_all.py` unchanged.
+- Unit-test deterministic `chain_id`;
+- Unit-test missing province failure;
+- Unit-test fail-soft status calculation;
+- Unit-test artifact writing;
+- Unit-test court event insertion;
+- Integration-test a small mock chain without mutating treasury;
+- Verify `python -m pytest tests/` and `python tools/validate_all.py`.
 
 ## Alternatives Considered
 
-- New protocol v3 with chain-native input/output: more powerful but unnecessary for the first V0.4 version.
-- Parallel DAG execution: deferred to V0.5+.
+### New protocol v3
+
+Rejected for V0.4 MVP. It would be more expressive, but V0.3 intentionally froze v2. Chain mode can be implemented as additive optional context.
+
+### Merge every step delta
+
+Rejected for MVP. It creates ambiguity around partial failure and resource conservation. Chain artifacts should be ceremonial/read-only first.
+
+### Parallel DAG execution
+
+Deferred to V0.5+. It requires a separate scheduler and artifact model.
 
 ## Drawbacks
 
-- More court complexity;
-- More runtime cost per tick;
-- Ambiguous resource semantics if chain steps mutate treasury.
+- More subprocess work when chain mode is invoked;
+- Chain-specific behavior is optional, so many provinces will initially return generic events;
+- Artifact-only semantics may feel less “gameplay-rich” than treasury mutation.
 
 ## Open Questions
 
-- Should chain steps be allowed to mutate treasury, or only produce ceremonial artifacts?
-- Should partial success create an event or fail the whole chain?
-- Where should chain artifacts live: `empire/artifacts/`, `empire/seals/`, or a new directory?
+- Should V0.5 add dashboard chain artifact rendering?
+- Should V0.5 allow chain recipes declared in manifest or state?
+- Should successful chain participation grant a small loyalty/title bonus?
 
 ## Decision Log
 
 - 2026-05-04: Draft placeholder created during V0.4 governance setup.
+- 2026-05-04: Accepted MVP direction: court-owned, v2-compatible, fail-soft, artifact-only.

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from court import chain
+
+
+BASE_STATE: Dict[str, Any] = {
+    "schema_version": 1,
+    "dynasty": "秦",
+    "tick": 123,
+    "year": 5,
+    "stage": "chun-qiu",
+    "treasury": {"wen-shu": 10},
+    "provinces": {
+        "python": {"level": 1, "loyalty": 100, "last_tick": 0},
+        "c": {"level": 1, "loyalty": 100, "last_tick": 0},
+        "sql": {"level": 1, "loyalty": 100, "last_tick": 0},
+    },
+    "events": [],
+}
+
+
+def manifest(pid: str, role: str = "producer") -> Dict[str, Any]:
+    return {
+        "id": pid,
+        "name": pid.title(),
+        "province": f"{pid}郡",
+        "role": role,
+        "produces": ["wen-shu"],
+        "run": "unused",
+        "__cwd": ".",
+        "timeout_ms": 3000,
+        "permissions": {},
+    }
+
+
+def ok_runner(m: Dict[str, Any], dispatch: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "language": m["name"],
+        "province": m["province"],
+        "ok": True,
+        "tick": dispatch["tick"],
+        "dispatch_id": dispatch["dispatch_id"],
+        "deltas": {"treasury": {"wen-shu": 999}},
+        "events": [{"type": "chain-step", "text": f"{m['id']} stamped", "severity": "info"}],
+        "__status": "passed",
+    }
+
+
+def test_build_chain_id_is_deterministic():
+    assert chain.build_chain_id(7, ["python", "c", "sql"]) == "chain-000007-python-c-sql"
+    assert chain.build_chain_id(7, []) == "chain-000007-empty"
+
+
+def test_run_chain_passed_writes_artifact_and_event(tmp_path: Path):
+    state = json.loads(json.dumps(BASE_STATE))
+    record = chain.run_chain(
+        state=state,
+        manifests=[manifest("python"), manifest("c"), manifest("sql")],
+        province_ids=["python", "c", "sql"],
+        title="书同文小典",
+        payload={"text": "秦法同文"},
+        empire_dir=tmp_path,
+        run_province=ok_runner,
+    )
+
+    assert record["status"] == "passed"
+    assert record["artifact"] == "chains/chain-000123-python-c-sql.json"
+    assert len(record["steps"]) == 3
+    assert all(step["ok"] for step in record["steps"])
+    assert state["events"][0]["type"] == "chain"
+    assert state["events"][0]["artifact"] == record["artifact"]
+    artifact_path = tmp_path / record["artifact"]
+    assert artifact_path.exists()
+    artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+    assert artifact["payload"] == {"text": "秦法同文"}
+    assert artifact["events"][0]["text"] == "python stamped"
+
+
+def test_run_chain_does_not_merge_deltas_or_touch_province_state(tmp_path: Path):
+    state = json.loads(json.dumps(BASE_STATE))
+    before_treasury = dict(state["treasury"])
+    before_python = dict(state["provinces"]["python"])
+
+    chain.run_chain(
+        state=state,
+        manifests=[manifest("python")],
+        province_ids=["python"],
+        title="不动国库",
+        empire_dir=tmp_path,
+        run_province=ok_runner,
+    )
+
+    assert state["treasury"] == before_treasury
+    assert state["provinces"]["python"] == before_python
+
+
+def test_run_chain_partial_on_missing_province(tmp_path: Path):
+    state = json.loads(json.dumps(BASE_STATE))
+    record = chain.run_chain(
+        state=state,
+        manifests=[manifest("python")],
+        province_ids=["python", "missing"],
+        title="半成之链",
+        empire_dir=tmp_path,
+        run_province=ok_runner,
+    )
+
+    assert record["status"] == "partial"
+    assert record["steps"][0]["ok"] is True
+    assert record["steps"][1]["status"] == "missing"
+    assert record["steps"][1]["error"]["code"] == "CHAIN_MISSING"
+
+
+def test_run_chain_failed_when_all_steps_fail(tmp_path: Path):
+    state = json.loads(json.dumps(BASE_STATE))
+    record = chain.run_chain(
+        state=state,
+        manifests=[],
+        province_ids=["missing"],
+        title="皆不至",
+        empire_dir=tmp_path,
+        run_province=ok_runner,
+    )
+
+    assert record["status"] == "failed"
+    assert record["steps"][0]["status"] == "missing"
+
+
+def test_dispatch_contains_chain_context(tmp_path: Path):
+    state = json.loads(json.dumps(BASE_STATE))
+    seen = []
+
+    def runner(m: Dict[str, Any], dispatch: Dict[str, Any]) -> Dict[str, Any]:
+        seen.append(dispatch)
+        return ok_runner(m, dispatch)
+
+    chain.run_chain(
+        state=state,
+        manifests=[manifest("python"), manifest("c")],
+        province_ids=["python", "c"],
+        title="上下文",
+        empire_dir=tmp_path,
+        run_province=runner,
+    )
+
+    assert seen[0]["dispatch_type"] == "ceremony"
+    assert seen[0]["context"]["chain"]["step_index"] == 0
+    assert seen[0]["context"]["chain"]["step_count"] == 2
+    assert seen[0]["context"]["chain"]["previous"] == []
+    assert seen[1]["context"]["chain"]["step_index"] == 1
+    assert len(seen[1]["context"]["chain"]["previous"]) == 1
+
+
+def test_max_steps_limits_province_ids(tmp_path: Path):
+    state = json.loads(json.dumps(BASE_STATE))
+    record = chain.run_chain(
+        state=state,
+        manifests=[manifest("python"), manifest("c"), manifest("sql")],
+        province_ids=["python", "c", "sql"],
+        title="限步",
+        empire_dir=tmp_path,
+        max_steps=2,
+        run_province=ok_runner,
+    )
+
+    assert record["province_ids"] == ["python", "c"]
+    assert record["chain_id"] == "chain-000123-python-c"


### PR DESCRIPTION
Closes #51
Closes #52

包含两个连续 commit：
1. rfc: accept RFC 0001 chain mode
2. feat(v0.4): implement chain mode MVP

实现内容：
- court/chain.py run_chain API
- deterministic chain_id
- artifact: empire/chains/<chain_id>.json
- fail-soft: passed / partial / failed
- 不 merge chain step deltas，不影响 treasury / loyalty / fail_streak
- emperor CLI: --chain python,c,sql --chain-title ... --chain-payload ...
- tests/test_chain.py 7 cases
- .gitignore ignores empire/chains/*.json

验证：
- python -m pytest tests/ -q => 46 passed
- python tools/validate_all.py => 15 ok
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/great-qin-runtime/qinlang-empire/pull/56" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->