### PR TITLE
feat(v0.4): add qinlang-province wrapper (closes #53)

### DIFF
--- a/court/province.py
+++ b/court/province.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+from . import dispatcher, registry, state as state_mod, ticker
+from tools import validate_all
+
+ROOT = Path(__file__).resolve().parent.parent
+PROVINCES_DIR = ROOT / "provinces"
+STATE_PATH = ROOT / "empire" / "state.json"
+
+RunProvince = Callable[[Dict[str, Any], Dict[str, Any]], Dict[str, Any]]
+
+
+def validate_province(province_id: str, *, provinces_dir: Path = PROVINCES_DIR) -> Dict[str, Any]:
+    schemas = validate_all.load_schemas()
+    errors: List[str] = []
+    warnings: List[str] = []
+    manifest_path = provinces_dir / province_id / "manifest.json"
+    if not manifest_path.exists():
+        return _report(False, province_id, "validate", errors=[f"manifest not found: {manifest_path}"])
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return _report(False, province_id, "validate", errors=[f"manifest JSON error: {exc}"])
+    if "manifest.schema.json" not in schemas:
+        errors.append("manifest.schema.json not found")
+    else:
+        validator = validate_all.make_validator(schemas, "manifest.schema.json")
+        for err in validator.iter_errors(manifest):
+            path = ".".join(str(x) for x in err.absolute_path) or "<root>"
+            errors.append(f"manifest schema: {path}: {err.message}")
+    if manifest.get("id") != province_id:
+        errors.append(f"manifest.id {manifest.get('id')!r} != directory id {province_id!r}")
+    source = manifest.get("source")
+    if source and not (manifest_path.parent / source).exists():
+        errors.append(f"source not found: {source}")
+    report = validate_all.Report()
+    validate_all.check_protocol_alignment(report, [manifest])
+    errors.extend(f"{where}: {msg}" for where, msg in report.errors)
+    warnings.extend(f"{where}: {msg}" for where, msg in report.warnings)
+    return _report(not errors, province_id, "validate", errors=errors, warnings=warnings, manifest=manifest)
+
+
+def dry_run_province(
+    province_id: str,
+    *,
+    provinces_dir: Path = PROVINCES_DIR,
+    run_province: RunProvince = dispatcher.run_province,
+) -> Dict[str, Any]:
+    manifest = _load_manifest_or_raise(province_id, provinces_dir)
+    dispatch = validate_all._build_test_dispatch(manifest)
+    result = run_province(manifest, dispatch)
+    return _report(bool(result.get("ok")), province_id, "dry-run", result=result, dispatch=dispatch)
+
+
+def run_single_province(
+    province_id: str,
+    *,
+    state_path: Path = STATE_PATH,
+    provinces_dir: Path = PROVINCES_DIR,
+    commit: bool = False,
+    run_province: RunProvince = dispatcher.run_province,
+) -> Dict[str, Any]:
+    manifest = _load_manifest_or_raise(province_id, provinces_dir)
+    state = state_mod.load_state(state_path)
+    state.setdefault("provinces", {}).setdefault(province_id, {
+        "level": 1,
+        "loyalty": 100,
+        "last_tick": 0,
+        "produced": 0,
+        "consumed": 0,
+        "fail_streak": 0,
+        "quarantined": False,
+    })
+    dispatch = ticker.build_dispatch(state, manifest)
+    result = run_province(manifest, dispatch)
+    if commit:
+        state_mod.merge_delta(state, manifest, result)
+        state_mod.save_state(state, state_path)
+        state_mod.append_history(state_path.parent / "history.jsonl", [{
+            "tick": state.get("tick", 0),
+            "year": state.get("year", 0),
+            "province_id": manifest["id"],
+            "province": manifest["province"],
+            "language": manifest["name"],
+            "ok": result.get("ok", False),
+            "status": result.get("__status", "unknown"),
+            "elapsed_ms": (result.get("metrics") or {}).get("elapsed_ms"),
+            "events": result.get("events", []),
+            "error": result.get("error"),
+        }])
+    return _report(bool(result.get("ok")), province_id, "run", result=result, dispatch=dispatch, committed=commit)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(prog="qinlang-province")
+    parser.add_argument("--json", action="store_true", help="输出机器可读 JSON")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_validate = sub.add_parser("validate", help="静态校验单个郡 manifest")
+    p_validate.add_argument("province_id")
+
+    p_dry = sub.add_parser("dry-run", help="用 validation dispatch 实跑单个郡，不写 state")
+    p_dry.add_argument("province_id")
+
+    p_run = sub.add_parser("run", help="用当前 state 实跑单个郡，默认不写回")
+    p_run.add_argument("province_id")
+    p_run.add_argument("--state-path", default=str(STATE_PATH))
+    p_run.add_argument("--commit", action="store_true", help="写回 state.json 并追加 history.jsonl")
+
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "validate":
+            report = validate_province(args.province_id, provinces_dir=PROVINCES_DIR)
+        elif args.command == "dry-run":
+            report = dry_run_province(args.province_id, provinces_dir=PROVINCES_DIR)
+        else:
+            report = run_single_province(
+                args.province_id,
+                state_path=Path(args.state_path),
+                provinces_dir=PROVINCES_DIR,
+                commit=args.commit,
+            )
+    except Exception as exc:
+        report = _report(False, getattr(args, "province_id", "<unknown>"), args.command or "unknown", errors=[str(exc)])
+
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+    else:
+        _print_human(report)
+    return 0 if report.get("ok") else 1
+
+
+def _load_manifest_or_raise(province_id: str, provinces_dir: Path) -> Dict[str, Any]:
+    manifests = registry.load_manifests(provinces_dir)
+    for manifest in manifests:
+        if manifest.get("id") == province_id:
+            return manifest
+    raise ValueError(f"province not found: {province_id}")
+
+
+def _report(ok: bool, province_id: str, command: str, **kwargs: Any) -> Dict[str, Any]:
+    report: Dict[str, Any] = {"ok": ok, "command": command, "province_id": province_id}
+    report.update(kwargs)
+    report.setdefault("errors", [])
+    report.setdefault("warnings", [])
+    return report
+
+
+def _print_human(report: Dict[str, Any]) -> None:
+    status = "ok" if report.get("ok") else "fail"
+    print(f"[{report.get('command')}] {report.get('province_id')}: {status}")
+    for warning in report.get("warnings") or []:
+        print(f"  warn: {warning}")
+    for error in report.get("errors") or []:
+        print(f"  error: {error}")
+    result = report.get("result") or {}
+    if result:
+        print(f"  status: {result.get('__status', 'unknown')}")
+        if result.get("error"):
+            print(f"  error: {result['error']}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -42,7 +42,7 @@ pip install -r requirements.txt
 
 - [ ] 标题符合 [命名规范 §7](naming-convention.md)；
 - [ ] `pytest tests/ -q` 全绿；
-- [ ] 受影响的郡能本地通过 `python -m court.emperor --province <id> --ticks 1`；
+- [ ] 受影响的郡能本地通过 `python -m court.province validate <id>` 与 `python -m court.province dry-run <id>`；
 - [ ] 如改协议 / 新分类 / 新 runner，已附 RFC 链接；
 - [ ] `python tools/validate_all.py` 全绿（manifest schema + dry-run）；
 - [ ] 文档随代码同步更新（README / catalog / language-addition-guide）；

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -42,11 +42,14 @@ python -m court.emperor --ticks 1
 [emperor] state 写回 empire/state.json
 ```
 
-`empire/state.json` 是当前帝国状态；`empire/history.jsonl` 追加每 tick 的报告。
+`empire/state.json` 是当前帝国状态；`empire/history.jsonl` 追加每 tick 的报告。`python -m court.province run <id>` 默认不写回状态；需要写回时显式加 `--commit`。
 
 ## 4. 试一试单郡
 
 ```bash
+python -m court.province validate python
+python -m court.province dry-run python
+python -m court.province run python
 python -m court.emperor --province python --ticks 1
 python -m court.emperor --province rust --ticks 1
 python -m court.emperor --province sql --ticks 1

--- a/qinlang-province.py
+++ b/qinlang-province.py
@@ -1,0 +1,5 @@
+from court.province import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_province_wrapper.py
+++ b/tests/test_province_wrapper.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from court import province
+
+
+def write_province(root: Path, pid: str = "demo") -> None:
+    pdir = root / pid
+    pdir.mkdir(parents=True)
+    (pdir / "main.py").write_text("print('{}')\n", encoding="utf-8")
+    (pdir / "manifest.json").write_text(json.dumps({
+        "schema_version": 2,
+        "id": pid,
+        "name": "Demo",
+        "province": "样例郡",
+        "category": "interpreted-language",
+        "runner": "direct",
+        "source": "main.py",
+        "build": None,
+        "run": "python main.py",
+        "input": "stdin-json",
+        "output": "stdout-json",
+        "timeout_ms": 3000,
+        "role": "producer",
+        "produces": ["wen-shu"],
+        "produce_rate": 1,
+        "cooldown_ticks": 1,
+        "tick_weight": 1.0,
+        "status": "runnable",
+        "tags": ["test"],
+        "description": "测试郡",
+        "permissions": {},
+    }), encoding="utf-8")
+
+
+def test_validate_province_ok(tmp_path: Path):
+    write_province(tmp_path)
+    report = province.validate_province("demo", provinces_dir=tmp_path)
+    assert report["ok"] is True
+    assert report["errors"] == []
+
+
+def test_validate_province_reports_missing_manifest(tmp_path: Path):
+    report = province.validate_province("missing", provinces_dir=tmp_path)
+    assert report["ok"] is False
+    assert "manifest not found" in report["errors"][0]
+
+
+def test_dry_run_uses_dispatcher_contract(tmp_path: Path):
+    write_province(tmp_path)
+    seen = []
+
+    def runner(manifest: Dict[str, Any], dispatch: Dict[str, Any]) -> Dict[str, Any]:
+        seen.append((manifest, dispatch))
+        return {
+            "language": manifest["name"],
+            "province": manifest["province"],
+            "ok": True,
+            "tick": dispatch["tick"],
+            "dispatch_id": dispatch["dispatch_id"],
+            "deltas": {},
+            "events": [],
+            "__status": "passed",
+        }
+
+    report = province.dry_run_province("demo", provinces_dir=tmp_path, run_province=runner)
+    assert report["ok"] is True
+    assert report["result"]["__status"] == "passed"
+    assert seen[0][1]["dispatch_id"] == "dispatch-validate-demo"
+
+
+def test_run_single_province_without_commit_does_not_write_state(tmp_path: Path):
+    write_province(tmp_path / "provinces")
+    state_path = tmp_path / "empire" / "state.json"
+    state_path.parent.mkdir()
+    original = {
+        "schema_version": 1,
+        "dynasty": "秦",
+        "tick": 9,
+        "year": 1,
+        "stage": "qin-yi",
+        "treasury": {"wen-shu": 1},
+        "provinces": {},
+        "events": [],
+    }
+    state_path.write_text(json.dumps(original, ensure_ascii=False), encoding="utf-8")
+
+    def runner(manifest: Dict[str, Any], dispatch: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "language": manifest["name"],
+            "province": manifest["province"],
+            "ok": True,
+            "tick": dispatch["tick"],
+            "dispatch_id": dispatch["dispatch_id"],
+            "deltas": {"treasury": {"wen-shu": 100}},
+            "events": [],
+            "__status": "passed",
+        }
+
+    report = province.run_single_province(
+        "demo",
+        state_path=state_path,
+        provinces_dir=tmp_path / "provinces",
+        commit=False,
+        run_province=runner,
+    )
+
+    assert report["ok"] is True
+    after = json.loads(state_path.read_text(encoding="utf-8"))
+    assert after == original
+
+
+def test_cli_json_validate(tmp_path: Path, monkeypatch, capsys):
+    write_province(tmp_path)
+    monkeypatch.setattr(province, "PROVINCES_DIR", tmp_path)
+    code = province.main(["--json", "validate", "demo"])
+    out = json.loads(capsys.readouterr().out)
+    assert code == 0
+    assert out["ok"] is True
+    assert out["command"] == "validate"


### PR DESCRIPTION
Closes #53

实现 V0.4 qinlang-province 包装器：
- python -m court.province validate <id>
- python -m court.province dry-run <id>
- python -m court.province run <id> [--commit]
- qinlang-province.py 根目录 shim
- 默认 run 不写 state，只有 --commit 才保存 state/history
- 复用 validate_all schema 检查与 dispatcher strict stdout 行为
- 更新 quickstart / contribution-guide

验证：
- python -m pytest tests/ -q => 51 passed
- python tools/validate_all.py => 15 ok
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/great-qin-runtime/qinlang-empire/pull/57" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->