### PR TITLE
ci(v0.4): OS matrix + GHCR image build (closes #55)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.github
+.venv
+__pycache__
+.pytest_cache
+*.pyc
+empire/chains/*.json
+empire/seals/*.svg
+node_modules
+.DS_Store

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,73 @@
+name: 镜像 / Docker
+
+on:
+  pull_request:
+    paths:
+      - 'Dockerfile'
+      - '.dockerignore'
+      - '.github/workflows/docker.yml'
+      - 'requirements.txt'
+      - 'court/**'
+      - 'tools/**'
+      - 'provinces/**'
+      - 'docs/protocol/**'
+  push:
+    branches: [main]
+    paths:
+      - 'Dockerfile'
+      - '.dockerignore'
+      - '.github/workflows/docker.yml'
+      - 'requirements.txt'
+      - 'court/**'
+      - 'tools/**'
+      - 'provinces/**'
+      - 'docs/protocol/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: 登录 GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 镜像元数据
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/great-qin-runtime/qinlang-empire
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: 构建并按需推送
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: PR 镜像 smoke test
+        if: github.event_name == 'pull_request'
+        run: |
+          docker build -t qinlang-empire:pr .
+          docker run --rm qinlang-empire:pr python tools/validate_all.py

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,10 +15,18 @@ on:
 permissions:
   contents: read
 
+env:
+  PYTHONUTF8: "1"
+
 jobs:
   validate:
-    runs-on: ubuntu-latest
-    timeout-minutes: 8
+    name: validate (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 12
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
 
@@ -30,15 +38,22 @@ jobs:
         with:
           node-version: '20'
 
-      - name: 安装依赖
+      - name: 安装 Python 依赖
+        run: python -m pip install --quiet -r requirements.txt pytest
+
+      - name: 安装 Ubuntu dry-run 工具链
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends jq sqlite3 build-essential ghc
-          pip install --quiet -r requirements.txt
           npm install --silent --global tsx
+
+      - name: 单元测试
+        run: python -m pytest tests/ -q
 
       - name: 静态校验（schema + 唯一性 + 协议匹配）
         run: python tools/validate_all.py
 
       - name: 协议级 dry-run（实际跑每郡一次 dispatch）
+        if: runner.os == 'Linux'
         run: python tools/validate_all.py --with-dry-run

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.11-slim-bookworm
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      build-essential \
+      ca-certificates \
+      curl \
+      git \
+      jq \
+      nodejs \
+      npm \
+      sqlite3 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+RUN python -m pip install --upgrade pip \
+    && python -m pip install -r requirements.txt pytest \
+    && npm install --global tsx
+
+COPY . .
+
+CMD ["python", "tools/validate_all.py"]

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -105,9 +105,9 @@ RFC（律令议案）用于所有会影响长期契约的设计变更。V0.3 起
 
 ## 8. 镜像与依赖
 
-1. Docker 镜像（待 V0.4 落地）统一发布到 `ghcr.io/Great-Qin-Runtime/qinlang-<id>` 或后续 RFC 指定命名空间；
+1. Docker 镜像统一发布到 `ghcr.io/great-qin-runtime/qinlang-<id>` 或后续 RFC 指定命名空间；
 2. 镜像必须基于 LTS 基础镜像，避免 `latest` 标签；
-3. 镜像构建脚本必须在仓库内可见（`tools/docker/<id>/Dockerfile`，目录尚未建立）；
+3. 镜像构建脚本必须在仓库内可见（基础镜像使用根 `Dockerfile`；分郡镜像可使用 `tools/docker/<id>/Dockerfile`）；
 4. 不允许在 `manifest.json` 中引用未发布的私人镜像。
 
-> ⚠️ 当前 V0.4 启动阶段尚未引入 docker runner；所有 docker 相关条款仍需 RFC/实现 PR 落地。
+> V0.4 先落地基础镜像构建与 GHCR 发布；docker runner / 运行时隔离仍需后续 RFC/实现 PR。


### PR DESCRIPTION
Closes #55

实现 V0.4 Docker/CI matrix 基础：
- validate.yml 改为 ubuntu/macos/windows matrix
- 全平台运行 pytest + 静态 validate_all
- Ubuntu 保留完整 dry-run toolchain job
- 新增根 Dockerfile + .dockerignore
- 新增 docker.yml：PR 构建 smoke test，main push 发布 ghcr.io/great-qin-runtime/qinlang-empire
- 更新 governance 镜像命名约定

验证：
- python -m pytest tests/ -q => 57 passed
- python tools/validate_all.py => 15 ok
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/great-qin-runtime/qinlang-empire/pull/59" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->