### PR TITLE
feat(provinces): add config data language batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 > 大事记录于此，分版而书。  
 > 格式参考 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/) 与 [SemVer](https://semver.org/lang/zh-CN/)。
 
+## [Unreleased]
+
+### Added
+
+- **配置 / 数据声明五郡**：新增 JSON（度量郡）、TOML（表头郡）、XML（尖括郡）、CSV（列点郡）、INI（节段郡）五个 runnable province，统一使用 Python 标准库 wrapper 执行对应数据源，扩展到 20 个 manifest。
+
+---
+
 ## [v0.4.0] · 2026-05-04 · 车同轨
 
 **主题**：chain mode · 单郡工具链 · hard permissions · 跨平台 CI / GHCR 镜像
@@ -136,6 +144,7 @@
 
 ---
 
+[Unreleased]: https://github.com/Great-Qin-Runtime/qinlang-empire/compare/v0.4.0...main
 [v0.4.0]: https://github.com/Great-Qin-Runtime/qinlang-empire/releases/tag/v0.4.0
 [v0.3.0]: https://github.com/Great-Qin-Runtime/qinlang-empire/releases/tag/v0.3.0
 [v0.2.0]: https://github.com/Great-Qin-Runtime/qinlang-empire/tree/main

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ qinlang-empire/
 ├── empire/
 │   ├── state.json        帝国当前状态（cron 每 tick 改写）
 │   └── history.jsonl     完整 tick 报告流
-├── provinces/            郡（V0.2 已 15 郡入册）
+├── provinces/            郡（V0.5 已 20 郡入册）
 │   ├── python/      · 白蛇郡 · producer    · 文书
 │   ├── c/           · 始源郡 · producer    · 工具
 │   ├── rust/        · 锈铁郡 · producer    · 兵器
@@ -112,6 +112,11 @@ qinlang-empire/
 │   ├── jq/          · 角铲郡 · transformer · 典籍
 │   ├── prolog/      · 律令郡 · service     · 律令
 │   ├── glsl/        · 着色郡 · specialist  · 天象
+│   ├── json/        · 度量郡 · service     · 户籍
+│   ├── toml/        · 表头郡 · producer    · 文书
+│   ├── xml/         · 尖括郡 · service     · 典籍
+│   ├── csv/         · 列点郡 · service     · 钱粮
+│   ├── ini/         · 节段郡 · producer    · 工具
 │   ├── brainfuck/   · 奇技郡 · ceremonial  · 烟火
 │   └── whitespace/  · 无字郡 · ceremonial  · 静默
 ├── tools/
@@ -163,7 +168,7 @@ qinlang-empire/
 - **自动运行**——CI cron + 静态网页 = 没有服务器，没有运维，只有继续跑；
 - **永远是秦**——这不是模拟器，是叙事。你看到的是同一个帝国，在长。
 
-## 七、当前状态（V0.4 完成 · 车同轨）
+## 七、当前状态（V0.5 进行中 · 帝国舆图）
 
 | 组件 | 状态 |
 |---|---|
@@ -186,6 +191,7 @@ qinlang-empire/
 | `manifest.permissions` hard preflight（fs/subprocess） | ✅ V0.4 |
 | CI 矩阵：Linux / macOS / Windows | ✅ V0.4 |
 | Docker / GHCR 基础镜像构建 | ✅ V0.4 |
+| 配置 / 数据声明五郡（JSON / TOML / XML / CSV / INI） | ✅ V0.5 |
 | GitHub Pages 部署 | ⚠️ 需在仓库 Settings 中启用 Pages |
 | docker runner / 运行时隔离 | 🚧 V0.5+ |
 | Nix flake 支持 | 🚧 P1 |

--- a/docs/catalog/languages.catalog.seed.json
+++ b/docs/catalog/languages.catalog.seed.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../protocol/manifest.schema.json",
   "version": 1,
-  "comment": "Seed 数据：V0.1 第一批 20 种语言。完整登记表暂时直接维护在本文件。",
+  "comment": "Seed 数据：核心语言与当前可运行扩展。完整登记表暂时直接维护在本文件。",
   "languages": [
     {
       "id": "python",
@@ -148,6 +148,51 @@
       "runner": "query",
       "status": "runnable",
       "tags": ["mainstream", "query"]
+    },
+    {
+      "id": "json",
+      "name": "JSON",
+      "province": "度量郡",
+      "category": "config-data-language",
+      "runner": "query",
+      "status": "runnable",
+      "tags": ["config", "data"]
+    },
+    {
+      "id": "toml",
+      "name": "TOML",
+      "province": "表头郡",
+      "category": "config-data-language",
+      "runner": "query",
+      "status": "runnable",
+      "tags": ["config", "data"]
+    },
+    {
+      "id": "xml",
+      "name": "XML",
+      "province": "尖括郡",
+      "category": "config-data-language",
+      "runner": "query",
+      "status": "runnable",
+      "tags": ["config", "data"]
+    },
+    {
+      "id": "csv",
+      "name": "CSV",
+      "province": "列点郡",
+      "category": "config-data-language",
+      "runner": "query",
+      "status": "runnable",
+      "tags": ["config", "data"]
+    },
+    {
+      "id": "ini",
+      "name": "INI",
+      "province": "节段郡",
+      "category": "config-data-language",
+      "runner": "query",
+      "status": "runnable",
+      "tags": ["config", "data"]
     },
     {
       "id": "r",

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -37,7 +37,7 @@ python -m court.emperor --ticks 1
 期望输出（数字会随阶段变化）：
 
 ```text
-[emperor] 15 郡入册：[bash, brainfuck, c, glsl, go, ...]
+[emperor] 20 郡入册：[bash, brainfuck, c, csv, glsl, go, ...]
 [tick   nn/year   k] 5/5 ok, 320 ms
 [emperor] state 写回 empire/state.json
 ```

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,7 +13,7 @@ V0.5 帝国舆图: 可视化与报告（4 周）         🚧
 V1.0 六合一统: 100+ 语言、稳定协议、可贡献社区
 ```
 
-时间为建议节奏，实际取决于贡献者数量。当前状态：**V0.4 已完成（chain mode、单郡 wrapper、hard permissions preflight、跨平台 CI、GHCR 基础镜像全部到位），V0.5 进入规划**。
+时间为建议节奏，实际取决于贡献者数量。当前状态：**V0.4 已完成（chain mode、单郡 wrapper、hard permissions preflight、跨平台 CI、GHCR 基础镜像全部到位），V0.5 已启动**。
 
 ---
 
@@ -113,8 +113,9 @@ python -m court.emperor --ticks 1
 
 里程碑事件：**Dashboard 可视化上线**
 
-| 任务 | 优先级 |
+| 任务 | 优先级 / 状态 |
 |---|---|
+| 配置 / 数据声明五郡（JSON / TOML / XML / CSV / INI） | ✅ |
 | Dashboard 首页（语言计数 / 类型饼图） | P0 |
 | 语言详情页 | P0 |
 | 战报页（最近一次运行） | P0 |

--- a/provinces/csv/README.md
+++ b/provinces/csv/README.md
@@ -1,0 +1,13 @@
+# CSV · 列点郡
+
+简介：列点郡用 CSV 表格盘点仓廪，负责产出钱粮增量。
+
+## 工具链
+- 解释器：Python 3.11+
+- 依赖：标准库 `csv`
+
+## 本地运行
+```bash
+python -m court.province validate csv
+python -m court.province dry-run csv
+```

--- a/provinces/csv/main.csv
+++ b/provinces/csv/main.csv
@@ -1,0 +1,4 @@
+granary,grain
+west,2
+east,3
+south,1

--- a/provinces/csv/manifest.json
+++ b/provinces/csv/manifest.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 2,
+  "id": "csv",
+  "name": "CSV",
+  "province": "列点郡",
+  "category": "config-data-language",
+  "runner": "query",
+  "source": "main.csv",
+  "build": null,
+  "run": "python run.py",
+  "input": "stdin-json",
+  "output": "stdout-json",
+  "timeout_ms": 3000,
+  "role": "service",
+  "trigger": "periodic",
+  "period_ticks": 1,
+  "service_type": "grain-ledger",
+  "produces": [
+    "qian-liang"
+  ],
+  "cooldown_ticks": 1,
+  "tick_weight": 0.8,
+  "status": "runnable",
+  "tags": [
+    "config",
+    "data",
+    "csv"
+  ],
+  "description": "列点郡，以 CSV 列账盘点仓廪钱粮。",
+  "permissions": {}
+}

--- a/provinces/csv/run.py
+++ b/provinces/csv/run.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import csv
+import json
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).parent
+
+
+def main() -> None:
+    payload = json.loads(sys.stdin.read())
+    dispatch = payload["dispatch"]
+    with (HERE / "main.csv").open("r", encoding="utf-8", newline="") as fh:
+        rows = list(csv.DictReader(fh))
+    level = int(dispatch.get("self", {}).get("level") or 1)
+    base = sum(int(row["grain"]) for row in rows)
+    amount = max(1, base + level - 1 + (int(dispatch["year"]) % 2))
+    out = {
+        "language": "CSV",
+        "province": "列点郡",
+        "ok": True,
+        "tick": dispatch["tick"],
+        "dispatch_id": dispatch.get("dispatch_id"),
+        "deltas": {
+            "treasury": {"qian-liang": amount},
+            "self": {"produced": amount},
+        },
+        "events": [
+            {
+                "type": "service",
+                "text": f"列点郡按 CSV 仓表盘点，入库钱粮 {amount} 石。",
+                "severity": "info",
+            }
+        ],
+    }
+    sys.stdout.write(json.dumps(out, ensure_ascii=False) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/provinces/ini/README.md
+++ b/provinces/ini/README.md
@@ -1,0 +1,13 @@
+# INI · 节段郡
+
+简介：节段郡用 INI 节段整理工坊器具，负责产出工具增量。
+
+## 工具链
+- 解释器：Python 3.11+
+- 依赖：标准库 `configparser`
+
+## 本地运行
+```bash
+python -m court.province validate ini
+python -m court.province dry-run ini
+```

--- a/provinces/ini/main.ini
+++ b/provinces/ini/main.ini
@@ -1,0 +1,5 @@
+[province]
+resource = gong-ju
+base = 2
+cycle = 3
+edict = 节段郡按 INI 条目整备工坊器具

--- a/provinces/ini/manifest.json
+++ b/provinces/ini/manifest.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": 2,
+  "id": "ini",
+  "name": "INI",
+  "province": "节段郡",
+  "category": "config-data-language",
+  "runner": "query",
+  "source": "main.ini",
+  "build": null,
+  "run": "python run.py",
+  "input": "stdin-json",
+  "output": "stdout-json",
+  "timeout_ms": 3000,
+  "role": "producer",
+  "produces": [
+    "gong-ju"
+  ],
+  "produce_rate": 2,
+  "cooldown_ticks": 1,
+  "tick_weight": 0.7,
+  "status": "runnable",
+  "tags": [
+    "config",
+    "data",
+    "ini"
+  ],
+  "description": "节段郡，以 INI 节段整理工坊器具。",
+  "permissions": {}
+}

--- a/provinces/ini/run.py
+++ b/provinces/ini/run.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import configparser
+import json
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).parent
+
+
+def main() -> None:
+    payload = json.loads(sys.stdin.read())
+    dispatch = payload["dispatch"]
+    config = configparser.ConfigParser()
+    config.read(HERE / "main.ini", encoding="utf-8")
+    section = config["province"]
+    level = int(dispatch.get("self", {}).get("level") or 1)
+    amount = section.getint("base") + (int(dispatch["tick"]) % section.getint("cycle")) + level - 1
+    resource = section["resource"]
+    out = {
+        "language": "INI",
+        "province": "节段郡",
+        "ok": True,
+        "tick": dispatch["tick"],
+        "dispatch_id": dispatch.get("dispatch_id"),
+        "deltas": {
+            "treasury": {resource: amount},
+            "self": {"produced": amount},
+        },
+        "events": [
+            {
+                "type": "produce",
+                "text": f"{section['edict']} {amount} 件。",
+                "severity": "info",
+            }
+        ],
+    }
+    sys.stdout.write(json.dumps(out, ensure_ascii=False) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/provinces/json/README.md
+++ b/provinces/json/README.md
@@ -1,0 +1,13 @@
+# JSON · 度量郡
+
+简介：度量郡用 JSON 记录量衡户册，负责把结构化清单转成帝国户籍增量。
+
+## 工具链
+- 解释器：Python 3.11+
+- 依赖：标准库 `json`
+
+## 本地运行
+```bash
+python -m court.province validate json
+python -m court.province dry-run json
+```

--- a/provinces/json/main.json
+++ b/provinces/json/main.json
@@ -1,0 +1,7 @@
+{
+  "registry": "measure-ledger",
+  "resource": "hu-ji",
+  "base": 2,
+  "cycle": 3,
+  "edict": "度量郡按 JSON 户册校准民籍。"
+}

--- a/provinces/json/manifest.json
+++ b/provinces/json/manifest.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 2,
+  "id": "json",
+  "name": "JSON",
+  "province": "度量郡",
+  "category": "config-data-language",
+  "runner": "query",
+  "source": "main.json",
+  "build": null,
+  "run": "python run.py",
+  "input": "stdin-json",
+  "output": "stdout-json",
+  "timeout_ms": 3000,
+  "role": "service",
+  "trigger": "periodic",
+  "period_ticks": 1,
+  "service_type": "measure-registry",
+  "produces": [
+    "hu-ji"
+  ],
+  "cooldown_ticks": 1,
+  "tick_weight": 0.8,
+  "status": "runnable",
+  "tags": [
+    "config",
+    "data",
+    "json"
+  ],
+  "description": "度量郡，以 JSON 定制量衡簿，校准各郡户籍尺度。",
+  "permissions": {}
+}

--- a/provinces/json/run.py
+++ b/provinces/json/run.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).parent
+
+
+def main() -> None:
+    payload = json.loads(sys.stdin.read())
+    dispatch = payload["dispatch"]
+    spec = json.loads((HERE / "main.json").read_text(encoding="utf-8"))
+    level = int(dispatch.get("self", {}).get("level") or 1)
+    amount = int(spec["base"]) + (int(dispatch["tick"]) % int(spec["cycle"])) + level - 1
+    out = {
+        "language": "JSON",
+        "province": "度量郡",
+        "ok": True,
+        "tick": dispatch["tick"],
+        "dispatch_id": dispatch.get("dispatch_id"),
+        "deltas": {
+            "treasury": {spec["resource"]: amount},
+            "self": {"produced": amount},
+        },
+        "events": [
+            {
+                "type": "service",
+                "text": f"{spec['edict']} 本轮新增 {amount} 户。",
+                "severity": "info",
+            }
+        ],
+    }
+    sys.stdout.write(json.dumps(out, ensure_ascii=False) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/provinces/toml/README.md
+++ b/provinces/toml/README.md
@@ -1,0 +1,13 @@
+# TOML · 表头郡
+
+简介：表头郡用 TOML 分章列项，负责产出格式严整的文书。
+
+## 工具链
+- 解释器：Python 3.11+
+- 依赖：标准库 `tomllib`
+
+## 本地运行
+```bash
+python -m court.province validate toml
+python -m court.province dry-run toml
+```

--- a/provinces/toml/main.toml
+++ b/provinces/toml/main.toml
@@ -1,0 +1,5 @@
+[province]
+resource = "wen-shu"
+base = 3
+cycle = 2
+edict = "表头郡按 TOML 章表修成文书"

--- a/provinces/toml/manifest.json
+++ b/provinces/toml/manifest.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": 2,
+  "id": "toml",
+  "name": "TOML",
+  "province": "表头郡",
+  "category": "config-data-language",
+  "runner": "query",
+  "source": "main.toml",
+  "build": null,
+  "run": "python run.py",
+  "input": "stdin-json",
+  "output": "stdout-json",
+  "timeout_ms": 3000,
+  "role": "producer",
+  "produces": [
+    "wen-shu"
+  ],
+  "produce_rate": 3,
+  "cooldown_ticks": 1,
+  "tick_weight": 0.8,
+  "status": "runnable",
+  "tags": [
+    "config",
+    "data",
+    "toml"
+  ],
+  "description": "表头郡，以 TOML 分章列项，产出规整文书。",
+  "permissions": {}
+}

--- a/provinces/toml/run.py
+++ b/provinces/toml/run.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+import sys
+import tomllib
+from pathlib import Path
+
+HERE = Path(__file__).parent
+
+
+def main() -> None:
+    payload = json.loads(sys.stdin.read())
+    dispatch = payload["dispatch"]
+    spec = tomllib.loads((HERE / "main.toml").read_text(encoding="utf-8"))["province"]
+    level = int(dispatch.get("self", {}).get("level") or 1)
+    amount = int(spec["base"]) + (int(dispatch["year"]) % int(spec["cycle"])) + level - 1
+    out = {
+        "language": "TOML",
+        "province": "表头郡",
+        "ok": True,
+        "tick": dispatch["tick"],
+        "dispatch_id": dispatch.get("dispatch_id"),
+        "deltas": {
+            "treasury": {spec["resource"]: amount},
+            "self": {"produced": amount},
+        },
+        "events": [
+            {
+                "type": "produce",
+                "text": f"{spec['edict']} {amount} 卷。",
+                "severity": "info",
+            }
+        ],
+    }
+    sys.stdout.write(json.dumps(out, ensure_ascii=False) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/provinces/xml/README.md
+++ b/provinces/xml/README.md
@@ -1,0 +1,13 @@
+# XML · 尖括郡
+
+简介：尖括郡用 XML 标记典章层级，负责校录帝国典籍。
+
+## 工具链
+- 解释器：Python 3.11+
+- 依赖：标准库 `xml.etree.ElementTree`
+
+## 本地运行
+```bash
+python -m court.province validate xml
+python -m court.province dry-run xml
+```

--- a/provinces/xml/main.xml
+++ b/provinces/xml/main.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<province resource="dian-ji" base="1" cycle="4">
+  <edict>尖括郡按 XML 层级校录典籍</edict>
+</province>

--- a/provinces/xml/manifest.json
+++ b/provinces/xml/manifest.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 2,
+  "id": "xml",
+  "name": "XML",
+  "province": "尖括郡",
+  "category": "config-data-language",
+  "runner": "query",
+  "source": "main.xml",
+  "build": null,
+  "run": "python run.py",
+  "input": "stdin-json",
+  "output": "stdout-json",
+  "timeout_ms": 3000,
+  "role": "service",
+  "trigger": "periodic",
+  "period_ticks": 2,
+  "service_type": "archive-index",
+  "produces": [
+    "dian-ji"
+  ],
+  "cooldown_ticks": 1,
+  "tick_weight": 0.7,
+  "status": "runnable",
+  "tags": [
+    "config",
+    "data",
+    "xml"
+  ],
+  "description": "尖括郡，以 XML 标记典章层级，校录帝国典籍。",
+  "permissions": {}
+}

--- a/provinces/xml/run.py
+++ b/provinces/xml/run.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+HERE = Path(__file__).parent
+
+
+def main() -> None:
+    payload = json.loads(sys.stdin.read())
+    dispatch = payload["dispatch"]
+    root = ET.parse(HERE / "main.xml").getroot()
+    level = int(dispatch.get("self", {}).get("level") or 1)
+    base = int(root.attrib["base"])
+    cycle = int(root.attrib["cycle"])
+    amount = base + (int(dispatch["tick"]) % cycle) + level - 1
+    edict = root.findtext("edict") or "尖括郡校录典籍"
+    resource = root.attrib["resource"]
+    out = {
+        "language": "XML",
+        "province": "尖括郡",
+        "ok": True,
+        "tick": dispatch["tick"],
+        "dispatch_id": dispatch.get("dispatch_id"),
+        "deltas": {
+            "treasury": {resource: amount},
+            "self": {"produced": amount},
+        },
+        "events": [
+            {
+                "type": "service",
+                "text": f"{edict} {amount} 卷。",
+                "severity": "info",
+            }
+        ],
+    }
+    sys.stdout.write(json.dumps(out, ensure_ascii=False) + "\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
V0.5 扩郡第一批：新增 5 个低风险配置 / 数据声明语言郡。

新增 province：
- JSON · 度量郡 · service · hu-ji
- TOML · 表头郡 · producer · wen-shu
- XML · 尖括郡 · service · dian-ji
- CSV · 列点郡 · service · qian-liang
- INI · 节段郡 · producer · gong-ju

实现方式：
- 每郡保留对应语言源文件：main.json / main.toml / main.xml / main.csv / main.ini
- 使用 Python 标准库 wrapper 做协议 I/O，避免新增外部工具链依赖
- permissions 均为空对象，保持 V0.4 hard preflight 低风险

文档/登记：
- README 目录布局和当前状态更新为 20 郡
- docs/catalog/languages.catalog.seed.json 登记 5 郡
- docs/quickstart.md 示例更新为 20 郡
- docs/roadmap.md 标记 V0.5 扩郡起步
- CHANGELOG.md 增加 Unreleased 条目

验证：
- python -m court.province dry-run json/toml/xml/csv/ini => passed
- python -m pytest tests/ -q => 57 passed
- python tools/validate_all.py => 20 manifests · 20 ok · 0 warnings · 0 errors

说明：Windows 本地全量 --with-dry-run 仍受既有 C/toolchain 项影响；新增 5 郡逐个 dry-run 均通过。
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/great-qin-runtime/qinlang-empire/pull/61" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->