### PR TITLE
fix(dashboard): render runnable catalog provinces

### DIFF
--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -6,6 +6,7 @@
  */
 
 const STATE_URL  = "../empire/state.json";
+const CATALOG_URL = "../docs/catalog/languages.catalog.seed.json";
 const REFRESH_MS = 30_000;
 
 const STAGE_NAMES = {
@@ -53,6 +54,14 @@ async function loadState() {
   return res.json();
 }
 
+async function loadCatalog() {
+  const url = `${CATALOG_URL}?ts=${Date.now()}`;
+  const res = await fetch(url, { cache: "no-store" });
+  if (!res.ok) return [];
+  const data = await res.json();
+  return (data.languages || []).filter(item => item.status === "runnable");
+}
+
 async function loadManifests() {
   // 我们没有列举接口；直接根据 state.provinces 的 keys 去 fetch 各 manifest。
   // 失败的 manifest 会被静默忽略，列表只用来做 dashboard 显示信息。
@@ -86,13 +95,13 @@ function escapeHtml(s) {
   }[c]));
 }
 
-function renderClock(state) {
+function renderClock(state, provinceCount) {
   bind("stageName", escapeHtml(STAGE_NAMES[state.stage] || state.stage));
   bind("year", state.year);
   bind("tick", state.tick);
   bind("season", escapeHtml(state.season || "—"));
   bind("weather", escapeHtml(state.weather || "—"));
-  bind("provinceCount", Object.keys(state.provinces || {}).length);
+  bind("provinceCount", provinceCount);
   const now = new Date();
   bind("updatedAt", `更新于 ${now.toLocaleTimeString("zh-Hans-CN")}`);
 }
@@ -116,7 +125,7 @@ function renderTreasury(state) {
   bind("treasuryList", items);
 }
 
-function renderProvinces(state, manifests) {
+function renderProvinces(state, manifests, ids) {
   const provinces = state.provinces || {};
   const recentlyActive = new Set();
   // 把"上一个 tick 出现的郡"标记为 active 高亮
@@ -124,7 +133,9 @@ function renderProvinces(state, manifests) {
     if (e.from_province) recentlyActive.add(e.from_province);
   }
 
-  const tiles = Object.entries(provinces).map(([id, ps]) => {
+  const renderIds = ids && ids.length ? ids : Object.keys(provinces);
+  const tiles = renderIds.map((id) => {
+    const ps = provinces[id] || {};
     const m = manifests[id] || {};
     const role = m.role || "producer";
     const provName = m.province || id;
@@ -134,10 +145,13 @@ function renderProvinces(state, manifests) {
     const cls = [
       "province",
       `role-${role}`,
+      provinces[id] ? "" : "pending",
       ps.quarantined ? "quarantined" : "",
       recentlyActive.has(id) ? "active" : "",
     ].filter(Boolean).join(" ");
-    const stat = ps.quarantined
+    const stat = !provinces[id]
+      ? "待诏"
+      : ps.quarantined
       ? "废"
       : `产 ${ps.produced || 0}　忠 ${loyalty}`;
     return `
@@ -211,13 +225,20 @@ function renderMilestones(state) {
 
 async function refresh() {
   try {
-    const state = await loadState();
-    const ids = Object.keys(state.provinces || {});
-    const manifests = await fetchManifestsFor(ids);
+    const [state, catalog] = await Promise.all([loadState(), loadCatalog()]);
+    const stateIds = Object.keys(state.provinces || {});
+    const catalogIds = catalog.map(item => item.id);
+    const fetchedManifests = await fetchManifestsFor(Array.from(new Set([...catalogIds, ...stateIds])));
+    const catalogManifests = Object.fromEntries(catalog.map(item => [item.id, item]));
+    const manifests = { ...catalogManifests, ...fetchedManifests };
+    const ids = Array.from(new Set([
+      ...Object.keys(fetchedManifests),
+      ...stateIds,
+    ])).sort();
 
-    renderClock(state);
+    renderClock(state, ids.length);
     renderTreasury(state);
-    renderProvinces(state, manifests);
+    renderProvinces(state, manifests, ids);
     renderEvents(state);
     renderMilestones(state);
     renderSeals(state);

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>大秦帝国 · QinLang Empire</title>
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=20260504-1">
 </head>
 <body>
   <header class="hall">
@@ -72,6 +72,6 @@
     <span>cron tick 间隔 5 分钟，本页自动刷新</span>
   </footer>
 
-  <script src="app.js"></script>
+  <script src="app.js?v=20260504-1"></script>
 </body>
 </html>

--- a/dashboard/style.css
+++ b/dashboard/style.css
@@ -210,6 +210,15 @@ main {
   filter: grayscale(1);
 }
 
+.province.pending {
+  opacity: 0.72;
+  border-style: dashed;
+}
+
+.province.pending .loyalty-bar > span {
+  background: var(--ink-mute);
+}
+
 .province .prov-name {
   font-size: 14px;
   font-weight: bold;


### PR DESCRIPTION
修复 GitHub Pages dashboard 看起来长期未更新的问题。

诊断：
- Pages 配置为 legacy main:/，最近部署成功
- empire-tick workflow 仍在成功运行
- 问题根因是 dashboard 只按 empire/state.json 的 provinces 渲染；新合并的 province 在首次被 tick 初始化前不会出现在 state.provinces，因此新增 5 郡不会显示

变更：
- dashboard/app.js 读取 docs/catalog/languages.catalog.seed.json 的 runnable 项
- 只展示能 fetch 到 manifest.json 的入册 province，并与 state.provinces 合并
- 尚未出现在 state 的 province 标记为 待诏 / pending
- dashboard/index.html 给 style.css/app.js 加版本参数，降低 Pages/浏览器缓存误判

验证：
- node --check dashboard/app.js
- python -m pytest tests/ -q => 57 passed
- python tools/validate_all.py => 20 manifests · 20 ok
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/great-qin-runtime/qinlang-empire/pull/62" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->